### PR TITLE
Temporary fix for Firefox

### DIFF
--- a/src/block/index.scss
+++ b/src/block/index.scss
@@ -77,7 +77,7 @@ $color-open-icon: #777;
 }
 
 .c-accordion__content[hidden="until-found"] {
-	display: revert;
+	/*display: revert;*/
 }
 
 // Make all the content visible when printing the page.


### PR DESCRIPTION
Hi!

I found your fork, because you addressed the hidden until-found request https://github.com/philbuchanan/Accordion-Blocks/issues/161. Very much appreciated, as well as the vanilla JS version as a whole.

We only had a problem with Firefox. There the block are always initially opened and can't be closed. The problem ist the "display: revert". When I comment it out, everything seems fine. And I don't really see a difference. So maybe... :)

Somewhat off topic: it seems btw. like the until-found behavior could be implemented for Firefox pretty easily, too. That would be very cool. But I'm well aware that you are not the/a plugin maintainer and so it really is just a note :)
See: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden

